### PR TITLE
WIP: Password + Two Factor Authentication Support

### DIFF
--- a/src/routers/vault/middlewares/account.js
+++ b/src/routers/vault/middlewares/account.js
@@ -28,6 +28,7 @@ const update_account = async (req, res, next) => {
         primary:  +validate.get_prop(req, "primary"),
         allow:     validate.get_prop(req, "allow") === "true",
         strict:    validate.get_prop(req, "strict") === "true",
+        2fa:       validate.get_prop(req, "2fa") === "true",
     };
 
     const update_fields = {};
@@ -62,6 +63,10 @@ const update_account = async (req, res, next) => {
         // update allow non-primary
         update_fields.strictIPCheck = data.strict;
     }
+    if (session.allow2FA !== data.2fa) {
+        // update allow 2FA auth
+        update_fields.allow2FA = data.2fa;
+    }
 
     // update SQL
     if (Object.keys(update_fields).length) {
@@ -73,6 +78,7 @@ const update_account = async (req, res, next) => {
     // now update our cache
     session.allowNonPrimary = data.allow;
     session.strictIPCheck = data.strict;
+    session.allow2FA = data.allow2FA;
 
     for (const ident of session.identities) {
         if (ident.id === session.primaryIdentity.id) {

--- a/src/routers/vault/middlewares/session.js
+++ b/src/routers/vault/middlewares/session.js
@@ -156,6 +156,7 @@ const auth_session = async (req, res) => {
         session.primaryIdentity = ident;
         session.allowNonPrimary = user.allowNonPrimary;
         session.strictIPCheck = user.strictIPCheck;
+        session.allow2FA = user.allow2FA;
         session.identities.push(ident);
     } else {
         if (session.identity !== session.primaryIdentity && !session.allowNonPrimary) {
@@ -351,6 +352,7 @@ const new_session = async (req, res, next) => {
             session.primaryIdentity = primary;
             session.allowNonPrimary = account.allowNonPrimary;
             session.strictIPCheck = account.strictIPCheck;
+            session.allow2FA = account.allow2FA;
             session.identity = identity;
             req.app.locals.session.set(uuid, session);
 

--- a/src/routers/vault/models/vault/identity.js
+++ b/src/routers/vault/models/vault/identity.js
@@ -16,6 +16,10 @@ module.exports = {
             type: Sequelize.STRING(320),
             allowNull: false,
         },
+        totp: {
+            type: Sequelize.STRING(16),
+            allowNull: true,
+        },
         addedDate: {
             type: Sequelize.DATE,
             allowNull: false,

--- a/src/routers/vault/models/vault/identity.js
+++ b/src/routers/vault/models/vault/identity.js
@@ -20,6 +20,10 @@ module.exports = {
             type: Sequelize.STRING(16),
             allowNull: true,
         },
+        pass: {
+            type: Sequelize.STRING(128),
+            allowNull: true,
+        },
         addedDate: {
             type: Sequelize.DATE,
             allowNull: false,

--- a/src/routers/vault/models/vault/login.js
+++ b/src/routers/vault/models/vault/login.js
@@ -23,6 +23,12 @@ module.exports = {
             defaultValue: false,
             allowNull: false,
         },
+        allow2FA: {
+            field: "allow_2fa_login",
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+            allowNull: false,
+        },
         creationDate: {
             type: Sequelize.DATE,
             allowNull: false,

--- a/src/routers/vault/types/Identity.js
+++ b/src/routers/vault/types/Identity.js
@@ -22,6 +22,11 @@ class Identity extends Model {
      * the Vault user id
      * @type {number}
      */
+    //totp;
+    /**
+     * TOTP 16-chars base64 secret
+     * @type {string}
+     */
     //userId;
 
     /**

--- a/src/routers/vault/types/Identity.js
+++ b/src/routers/vault/types/Identity.js
@@ -24,7 +24,12 @@ class Identity extends Model {
      */
     //totp;
     /**
-     * TOTP 16-chars base64 secret
+     * TOTP 16-chars base64 secret (optional)
+     * @type {string}
+     */
+    //pass;
+    /**
+     * Optional PBKDF2 cryptographic secret to use with 2FA.
      * @type {string}
      */
     //userId;

--- a/src/routers/vault/types/Session.js
+++ b/src/routers/vault/types/Session.js
@@ -75,6 +75,10 @@ module.exports = class Session {
      * refuse to authenticate a session with a different IP
      */
     strictIPCheck = true;
+    /**
+     * allow to authenticate a session with 2FA + PBKDF2 password
+     */
+    allow2FA = false;
 
     constructor (ip, email) {
         this.ip = ip;
@@ -109,6 +113,7 @@ module.exports = class Session {
             primaryIdentity: this.primaryIdentity.id,
             allowNonPrimary: this.allowNonPrimary,
             strictIPCheck: this.strictIPCheck,
+            allow2FA: this.allow2FA,
             vaultId: this.vault,
         };
     }


### PR DESCRIPTION
This allows users to use a PBKDF2 + TOTP to login instead of email-based verification.

Patch is aimed to support SQL support for it; However there's no auth endpoint yet.
Do note this is disabled by default. User is supposed to explicitly allow this after having the email validated.

Of course, if they enable this and then get rid of their email... They will be able to use all TMW services except password or TOTP code recovery.

(TOTP doesn't have to be mandatory, however; Would even be cool if you could just set a password and optionally enable 2FA... Oh well.)

PS. Required by MLAPIv2.
Untested.